### PR TITLE
Replace Raycast calendar alias with direct EventKit integration

### DIFF
--- a/sketchybar/items/calendar.sh
+++ b/sketchybar/items/calendar.sh
@@ -1,71 +1,17 @@
 #!/usr/bin/env sh
 
-# Remove the existing calendar item if it exists
-sketchybar --remove calendar 2>/dev/null
 sketchybar --remove calendar_watcher 2>/dev/null
+sketchybar --remove calendar 2>/dev/null
 
-# Define parameters as an array
-CALENDAR_PARAMS=(
-  update_freq=1
-  label.padding_left=5
-  label.padding_right=0
-  background.color=$LIGHT_GREY
-  background.height=26
-  background.corner_radius=5
-  drawing=on
-  position=right
-)
-
-# Create a watcher item that will constantly check for Raycast calendar status
-calendar_watcher_script="
-# Check if Raycast is running and the calendar item exists
-if pgrep -x \"Raycast\" >/dev/null && sketchybar --query default_menu_items | grep \"raycastCalendarStatusItem\" >/dev/null; then
-  # If calendar doesn't exist, create it
-  if ! sketchybar --query item calendar >/dev/null 2>&1; then
-    # Create the alias with the correct position on the far right
-    sketchybar --add alias \"Control Center,raycastCalendarStatusItem\" right \\
-               --rename \"Contol Center,raycastCalendarStatusItem\" calendar \\
-               --set calendar update_freq=1 \\
-                          label.padding_left=5 \\
-                          label.padding_right=0 \\
-                          background.color=$LIGHT_GREY \\
-                          background.height=26 \\
-                          background.corner_radius=5 \\
-                          drawing=off \\
-                          position=right
-
-    # Handle placement with delay in background,
-    # this is a bit of a hack but we don't get the alias screen recording callback
-    (
-      sleep 5s
-      sketchybar --move calendar before time
-      sketchybar --set calendar drawing=on
-    ) &
-  fi
-else
-  # Remove calendar if it exists but shouldn't
-  if sketchybar --query item calendar >/dev/null 2>&1; then
-    sketchybar --remove calendar
-  fi
-fi
-"
-
-# Create a hidden watcher item that periodically checks for Raycast
-sketchybar --add item calendar_watcher left \
-           --set calendar_watcher script="$calendar_watcher_script" \
-                                 update_freq=1 \
-                                 drawing=on
-
-# Check if Raycast is running initially
-if pgrep -x "Raycast" >/dev/null; then
-  # Check if the Raycast calendar item exists
-  if sketchybar --query default_menu_items | grep "raycastCalendarStatusItem" >/dev/null; then
-    # Create the alias directly
-    sketchybar --add alias "Control Center,raycastCalendarStatusItem" right \
-               --rename "Control Center,raycastCalendarStatusItem" calendar \
-               --set calendar "${CALENDAR_PARAMS[@]}"
-  fi
-fi
-
-# Trigger the watcher to start monitoring
-sketchybar --trigger script calendar_watcher
+sketchybar --add item calendar right \
+           --set calendar script="$PLUGIN_DIR/calendar_plugin.sh" \
+                          update_freq=30 \
+                          updates=when_shown \
+                          label.padding_left=5 \
+                          label.padding_right=13 \
+                          background.color=$LIGHT_GREY \
+                          background.height=26 \
+                          background.corner_radius=5 \
+                          background.drawing=off \
+                          drawing=on \
+           --subscribe calendar system_woke

--- a/sketchybar/plugins/calendar_plugin.sh
+++ b/sketchybar/plugins/calendar_plugin.sh
@@ -1,22 +1,58 @@
 #!/usr/bin/env sh
 
-# Check if Raycast is running
-if pgrep -x "Raycast" >/dev/null; then
-  # Check if the Raycast calendar item exists
-  if sketchybar --query default_menu_items | grep "raycastCalendarStatusItem" >/dev/null; then
-    # Check if we need to create an alias
-    if ! sketchybar --query item calendar > /dev/null 2>&1; then
-      # Create the alias
-      sketchybar --add alias "Raycast,raycastCalendarStatusItem" right --rename "Raycast,raycastCalendarStatusItem" calendar
-      sketchybar --set calendar update_freq=1                         label.padding_left=5                         label.padding_right=0                         background.color=0x44ffffff                         background.height=26                         background.corner_radius=5
-    fi
-    # Make it visible
-    sketchybar --set calendar drawing=on
-  else
-    # Hide it if it exists
-    sketchybar --set calendar drawing=off 2>/dev/null
-  fi
+RESULT=$(swift - << 'EOF'
+import Foundation
+import EventKit
+
+func truncate(_ s: String, _ max: Int) -> String {
+  guard s.count > max else { return s }
+  return String(s.prefix(max)) + "…"
+}
+
+func isZoom(_ event: EKEvent) -> Bool {
+  let fields = [event.url?.absoluteString, event.notes, event.location, event.title]
+  return fields.compactMap { $0 }.contains { $0.lowercased().contains("zoom") }
+}
+
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+
+store.requestFullAccessToEvents { granted, _ in
+  guard granted else { semaphore.signal(); return }
+
+  let now = Date()
+  let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: now)!
+  let pred = store.predicateForEvents(withStart: now - 3600, end: tomorrow, calendars: nil)
+  let events = store.events(matching: pred)
+    .filter { isZoom($0) }
+    .sorted { $0.startDate < $1.startDate }
+
+  // Check for an active meeting first
+  if let active = events.first(where: { $0.startDate <= now && $0.endDate > now }) {
+    let mins = Int(active.endDate.timeIntervalSince(now) / 60)
+    let title = truncate(active.title ?? "Meeting", 25)
+    print("active|\(title) · \(mins)m left")
+    semaphore.signal()
+    return
+  }
+
+  // Otherwise show next upcoming Zoom meeting
+  if let next = events.first(where: { $0.startDate > now }) {
+    let mins = Int(next.startDate.timeIntervalSince(now) / 60)
+    let title = truncate(next.title ?? "Meeting", 25)
+    let timeStr = mins < 60 ? "in \(mins)m" : "in \(mins / 60)h \(mins % 60)m"
+    print("upcoming|\(title) · \(timeStr)")
+  }
+
+  semaphore.signal()
+}
+semaphore.wait()
+EOF
+)
+
+if [ -z "$RESULT" ]; then
+  sketchybar --set "$NAME" label="" background.drawing=off
 else
-  # Hide it if it exists
-  sketchybar --set calendar drawing=off 2>/dev/null
+  LABEL="${RESULT#*|}"
+  sketchybar --set "$NAME" label="$LABEL" background.drawing=on
 fi

--- a/sketchybar/sketchybarrc
+++ b/sketchybar/sketchybarrc
@@ -62,8 +62,8 @@ source "$ITEM_DIR/apple.sh"
 source "$ITEM_DIR/spaces.sh"
 
 # Right
-source "$ITEM_DIR/calendar.sh"
 source "$ITEM_DIR/time.sh"
+source "$ITEM_DIR/calendar.sh"
 
 ############## FINALIZING THE SETUP ##############
 sketchybar --update


### PR DESCRIPTION
## Summary

- Replaces the Raycast menu bar alias approach for showing calendar events, which broke on macOS 26 (Tahoe) due to changed SkyLight APIs
- New implementation uses a Swift/EventKit plugin to query Calendar.app directly, filtering for Zoom meetings only
- Shows relative time until start for upcoming meetings ("Meeting · in 5m") and time remaining for active meetings ("Meeting · 3m left")
- Fixes the 30-second update timer by keeping the item always drawn (toggling background visibility instead of item visibility, which was preventing `updates=when_shown` from firing)
- Ensures clock stays on the far right by sourcing `time.sh` before `calendar.sh`

## Test plan

- [ ] Verify upcoming Zoom meetings show with relative start time
- [ ] Verify active Zoom meetings show time remaining
- [ ] Verify non-Zoom meetings are filtered out
- [ ] Verify item updates every 30 seconds without manual reload
- [ ] Verify clock remains on far right of bar
- [ ] Verify item hides (background disappears) when no Zoom meetings

🤖 Generated with [Claude Code](https://claude.com/claude-code)